### PR TITLE
fix(lint): resolve type-aware linting errors and properly scope ESLin…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Extra
+extra
+
 # Logs
 logs
 *.log

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,20 +2,31 @@
 import eslintPluginPrettier from 'eslint-plugin-prettier';
 import tseslint from 'typescript-eslint';
 import js from '@eslint/js';
+import path from 'path';
 
 export default [
     {
         ignores: [
             '.eslintrc.js',
             'eslint.config.js',
+            'vitest.config.ts',
+            'vitest.config.js',
             'node_modules',
             'dist',
             'build',
+            'extra/*.ts',
         ],
     },
     js.configs.recommended,
     ...tseslint.configs.recommended,
     {
+        files: ['src/**/*.ts'],
+        languageOptions: {
+            parserOptions: {
+                project: './tsconfig.eslint.json',
+                tsconfigRootDir: path.resolve(),
+            },
+        },
         plugins: {
             '@typescript-eslint': tseslint.plugin,
             prettier: eslintPluginPrettier,
@@ -28,10 +39,23 @@ export default [
                 {
                     selector: 'variable',
                     modifiers: ['const'],
+                    types: ['boolean', 'string', 'number'],
                     format: ['UPPER_CASE'],
                 },
                 { selector: 'typeLike', format: ['PascalCase'] },
                 { selector: 'enumMember', format: ['UPPER_CASE'] },
+                {
+                    selector: 'classProperty',
+                    modifiers: ['private'],
+                    format: ['camelCase'],
+                    trailingUnderscore: 'require',
+                },
+                {
+                    selector: 'parameterProperty',
+                    modifiers: ['private'],
+                    format: ['camelCase'],
+                    trailingUnderscore: 'require',
+                },
             ],
         },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
             "license": "ISC",
             "dependencies": {
                 "@types/express": "^5.0.3",
-                "express": "^5.1.0"
+                "dotenv": "^17.2.0",
+                "express": "^5.1.0",
+                "zod": "^4.0.5"
             },
             "devDependencies": {
                 "@eslint/js": "^9.30.1",
@@ -2296,6 +2298,18 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "17.2.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+            "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dunder-proto": {
@@ -6303,6 +6317,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
+            "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     },
     "dependencies": {
         "@types/express": "^5.0.3",
-        "express": "^5.1.0"
+        "dotenv": "^17.2.0",
+        "express": "^5.1.0",
+        "zod": "^4.0.5"
     },
     "devDependencies": {
         "@eslint/js": "^9.30.1",

--- a/src/configs/app.config.ts
+++ b/src/configs/app.config.ts
@@ -1,0 +1,12 @@
+/// src/configs/app.config.ts
+
+import dotenv from 'dotenv';
+import { appConfigSchema } from '../types/app.config.type.js';
+dotenv.config();
+
+const appConfig = appConfigSchema.safeParse({
+    port: process.env.PORT ? parseInt(process.env.PORT, 10) : 3737,
+    nodeEnv: process.env.NODE_ENV || 'Development',
+});
+
+export default appConfig;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 
-const APP = express();
+const app = express();
 
-APP.listen(3737, () => {
+app.listen(3737, () => {
     console.log('runnign on port 3737');
 });

--- a/src/types/app.config.type.ts
+++ b/src/types/app.config.type.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const appConfigSchema = z.object({
+    port: z.number().min(1000).max(65535).default(3737),
+    nodeEnv: z
+        .enum(['Development', 'Production', 'Test'])
+        .default('Development'),
+});
+
+export type AppConfig = z.infer<typeof appConfigSchema>;

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
…t config

- Limited type-aware rules to `src/**/*.ts` files only
- Excluded config and test files from type-aware parsing
- Updated ESLint config to use project-aware parserOptions selectively
- Ensured consistent naming conventions and Prettier integration