### PR TITLE
chore(lint): update naming-convention rule for import style in Flat E…

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,3 @@
-// eslint.config.js
 import eslintPluginPrettier from 'eslint-plugin-prettier';
 import tseslint from 'typescript-eslint';
 import js from '@eslint/js';
@@ -39,9 +38,16 @@ export default [
                 {
                     selector: 'variable',
                     modifiers: ['const'],
+                    format: ['camelCase', 'PascalCase'],
+                },
+                {
+                    selector: 'import', // ✅ valid for Flat Config
+                    format: ['camelCase', 'PascalCase'],
+                },
+                {
+                    selector: 'typeLike',
                     format: ['PascalCase'],
                 },
-                { selector: 'typeLike', format: ['PascalCase'] },
                 {
                     selector: 'enumMember',
                     format: ['UPPER_CASE', 'snake_case'],

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,5 @@
+import express from 'express';
+
+const App = express();
+
+export default App;

--- a/src/configs/app.config.ts
+++ b/src/configs/app.config.ts
@@ -1,13 +1,13 @@
 /// src/configs/app.config.ts
 
 import dotenv from 'dotenv';
-import { appConfigSchema } from '../types/app.config.type.js';
+import { AppConfigSchema } from '../types/app.config.type.js';
 import { z } from 'zod';
 import { ConfigValidationError } from '../errors/configValidation.error.js';
 
 dotenv.config();
 
-const AppConfigValidation = appConfigSchema.safeParse({
+const AppConfigValidation = AppConfigSchema.safeParse({
     PORT: process.env.PORT ? parseInt(process.env.PORT, 10) : 3737,
     NODE_ENV: process.env.NODE_ENV || 'Development',
 });
@@ -16,7 +16,7 @@ if (!AppConfigValidation.success) {
     throw new ConfigValidationError(AppConfigValidation.error);
 }
 
-type AppConfigType = z.infer<typeof appConfigSchema>;
+type AppConfigType = z.infer<typeof AppConfigSchema>;
 
 const AppConfig: AppConfigType = AppConfigValidation.data;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,6 @@
-import express from 'express';
+import App from './app.js';
+import AppConfig from './configs/app.config.js';
 
-const App = express();
-
-App.listen(3737, () => {
-    console.log('runnign on port 3737');
+App.listen(AppConfig.PORT || 3737, () => {
+    console.log(`GMTA : Server is running on port ${AppConfig.PORT || 3737}`);
 });


### PR DESCRIPTION
…SLint config

- Allowed PascalCase for import names (e.g., AppConfig)
- Fixed crash caused by invalid 'types' field in Flat Config
- Ensured consistent enforcement of camelCase and PascalCase across codebase